### PR TITLE
Fix issue with manifest conflicting with apps using library

### DIFF
--- a/pinchtozoom/src/main/AndroidManifest.xml
+++ b/pinchtozoom/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.bogdwellers.pinchtozoom">
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-    </application>
+    <application android:label="@string/app_name"/>
 </manifest>


### PR DESCRIPTION
The allowBackup and supportsRtl tags will conflict with applications that use this library but set a different value in the manifest for these settings, causeing build failures. While apps can configure their manifest to force override these settings, it is better just to disable them for library modules.

For more information on this issue, see https://bit.ly/2kkzXo0